### PR TITLE
feat (plugin): add latest posts block widget

### DIFF
--- a/wp-dsfr-blocks/src/fr-latest-posts/block.json
+++ b/wp-dsfr-blocks/src/fr-latest-posts/block.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "dsfr/fr-latest-posts",
+	"version": "1.0.0",
+	"title": "Derniers articles",
+	"category": "widgets",
+	"description": "Bloc DSFR derniers articles.",
+	"textdomain": "wp-dsfr-blocks",
+	"editorScript": "file:./index.js",
+	"render": "file:./render.php"
+}

--- a/wp-dsfr-blocks/src/fr-latest-posts/index.js
+++ b/wp-dsfr-blocks/src/fr-latest-posts/index.js
@@ -1,4 +1,5 @@
 import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 import metadata from './block.json';
 
 registerBlockType( metadata.name, {

--- a/wp-dsfr-blocks/src/fr-latest-posts/index.js
+++ b/wp-dsfr-blocks/src/fr-latest-posts/index.js
@@ -1,0 +1,22 @@
+import { registerBlockType } from '@wordpress/blocks';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	title: __( 'Dernières actualités', 'dsfr' ),
+	category: 'dsfr',
+	icon: 'megaphone',
+	edit: () => {
+		return (
+			<p>
+				{ __(
+					'Bloc affichant les 3 derniers articles de la catégorie actualités.',
+					'dsfr'
+				) }
+			</p>
+		);
+	},
+	save: () => {
+		// Rendered via PHP
+		return null;
+	},
+} );

--- a/wp-dsfr-blocks/src/fr-latest-posts/render.php
+++ b/wp-dsfr-blocks/src/fr-latest-posts/render.php
@@ -1,0 +1,27 @@
+<?php
+$posts_query = new WP_Query(
+	[
+		'category_name'  => 'actualites',
+		'posts_per_page' => 4,
+		'post_status'    => 'publish',
+	]
+);
+
+if ( ! $posts_query->have_posts() ) {
+	return;
+}
+?>
+<section class="latest-posts" style="max-width: 78rem;">
+	<div class="fr-container">
+		<div class="grid grid--fr-card-post" data-grid-size="3">
+			<?php
+			$i = 0;
+			while ( $posts_query->have_posts() ) :
+				$posts_query->the_post();
+				get_template_part( 'components/loops/card-post', 0 !== $i++ ? '' : 'highlight', [ 'heading_level' => 2 ] );
+			endwhile;
+			wp_reset_postdata();
+			?>
+		</div>
+	</div>
+</section>

--- a/wp-dsfr-blocks/wp-dsfr-blocks.php
+++ b/wp-dsfr-blocks/wp-dsfr-blocks.php
@@ -27,6 +27,7 @@ function dsfr_native_blocks_init() {
 		'fr-accordion',
 		'fr-accordion-title',
 		'fr-collapse',
+		'fr-latest-posts',
 		'fr-quote',
 		'fr-tabs',
 		'fr-tabs-list',

--- a/wp-dsfr-theme/inc/Services/Editor.php
+++ b/wp-dsfr-theme/inc/Services/Editor.php
@@ -338,6 +338,7 @@ class Editor implements Service {
 			'dsfr/fr-accordion',
 			'dsfr/fr-collapse',
 			'dsfr/fr-accordion-title',
+			'dsfr/fr-latest-posts',
 			'dsfr/fr-quote',
 			'dsfr/fr-tabs',
 			'dsfr/fr-tabs-list',


### PR DESCRIPTION
Bonjour,

Et merci de développer ce très bon thème.

Je vous propose une PR pour rajouter un block affichant les dernières actualités, similaire (mais largement simplifié) au block [`latest-posts`](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/latest-posts) par défaut de Gutenberg.

Max